### PR TITLE
Initial freedombox docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,106 @@
+# FROM ubuntu:16.04
+# ENV container docker
+# # Don't start any optional services except for the few we need.
+# RUN find /etc/systemd/system \
+#          /lib/systemd/system \
+#          -path '*.wants/*' \
+#          -not -name '*journald*' \
+#          -not -name '*systemd-tmpfiles*' \
+#          -not -name '*systemd-user-sessions*' \
+#          -exec rm \{} \;
+# RUN systemctl set-default multi-user.target
+# CMD ["/sbin/init"]
+
+FROM debian:buster
+ENV container docker
+ENV TERM dumb
+
+### install systemd
+RUN apt update 
+RUN apt-get install -y dialog apt-utils 
+#&& apt -y upgrade
+RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
+RUN apt -y install systemd resolvconf
+RUN systemctl set-default multi-user.target
+RUN ln -s /lib/systemd/systemd /sbin/init
+CMD ["/sbin/init"]
+
+### Update and upgrade and install some other packages.
+RUN apt-get update && \
+#    apt-get -y upgrade && \
+    apt-get -y install cron vim git wget curl unzip \
+               rsyslog logrotate ssmtp logwatch
+
+RUN apt-get -y install sudo
+
+RUN apt-get -y install \
+   augeas-tools \
+   dblatex \
+   docbook-utils \
+   e2fsprogs \
+   fonts-lato \
+   gettext \
+   gir1.2-glib-2.0 \
+   gir1.2-nm-1.0 \
+   ldapscripts \
+   libjs-bootstrap \
+   libjs-jquery \
+   libjs-modernizr \
+   make \
+   network-manager \
+   ppp \
+   pppoe \
+   python3 \
+   python3-apt \
+   python3-augeas \
+   python3-bootstrapform \
+   python3-cherrypy3 \
+   python3-configobj \
+   python3-coverage \
+   python3-django \
+   python3-django-axes \
+   python3-django-captcha \
+   python3-django-stronghold \
+   python3-gi \
+   python3-psutil \
+   python3-requests \
+   python3-ruamel.yaml \
+   python3-setuptools \
+   xmlto
+
+RUN git clone https://salsa.debian.org/freedombox-team/plinth.git && \
+cd plinth && python3 setup.py install
+
+RUN  DEBIAN_FRONTEND=noninteractive apt install -y $(plinth --list-dependencies)
+
+# ENTRYPOINT ["plinth"]
+### Install mariadb
+# RUN apt-get -y install software-properties-common && \
+#     apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8 && \
+#     add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.utexas.edu/mariadb/repo/10.2/ubuntu xenial main' && \
+#     apt-get update
+# RUN DEBIAN_FRONTEND=noninteractive \
+#     apt-get -y install mariadb-server mariadb-client
+
+### Install packages required by moodle.
+# RUN DEBIAN_FRONTEND=noninteractive \
+#     apt-get -y install \
+#             sudo apache2 
+# RUN DEBIAN_FRONTEND=noninteractive \
+#     apt-get -y install plinth 
+            # graphviz 
+            # aspell \
+            # php7.0 libapache2-mod-php7.0 php7.0-pspell php7.0-curl \
+            # php7.0-gd php7.0-intl php7.0-mysql php7.0-xml php7.0-xmlrpc \
+            # php7.0-ldap php7.0-zip php7.0-soap php7.0-mbstring
+
+### Install moosh (http://moosh-online.com/)
+# RUN apt-get -y install composer
+# RUN git clone git://github.com/tmuras/moosh.git /usr/local/src/moosh && \
+#     cd /usr/local/src/moosh && \
+#     composer install && \
+#     ln -s /usr/local/src/moosh/moosh.php /usr/local/bin/moosh
+
+### Get moodle code from git.
+#RUN git clone --progress --verbose git://git.moodle.org/moodle.git /usr/local/src/moodle
+#RUN git clone --progress --verbose https://github.com/moodle/moodle /usr/local/src/moodle

--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    {project}  Copyright (C) {year}  {fullname}
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
-# freedombox
-Docker scripts that install FreedomBox (https://wiki.debian.org/FreedomBox)
+moodle
+======
+
+Docker scripts that install and run Moodle in a container.
+
+## Install
+
+  - First install `ds` and `wsproxy`:
+     + https://github.com/docker-scripts/ds#installation
+     + https://github.com/docker-scripts/wsproxy#installation
+
+  - Then get the moodle scripts from github: `ds pull moodle`
+
+  - Create a directory for the moodle container: `ds init moodle @moodle1-example-org`
+
+  - Fix the settings:
+    ```
+    cd /var/ds/moodle1-example-org/
+    vim settings.sh
+    ds info
+    ```
+
+  - Create the container and install Moodle: `ds make`
+
+    *Note:* This will pull the image from DockerHub. To build the
+    image yourself use `ds build` first, however this is usually
+    slower.
+
+
+## Access the website
+
+If the domain is a real one, tell `wsproxy` to get a free
+letsencrypt.org SSL certificate for it:
+```
+ds wsproxy ssl-cert --test
+ds wsproxy ssl-cert
+```
+
+If the domain is not a real one, add to `/etc/hosts` the line
+`127.0.0.1 moodle1.example.org`
+
+Now you can access the website at: https://moodle1.example.org
+
+
+## Other commands
+
+```
+ds shell
+ds stop
+ds start
+ds help
+```
+
+## Backup and restore
+
+```
+ds backup
+ds backup +data
+ds restore backup-file.tgz
+```
+
+## Clone
+
+```
+ds clone tag
+ds clone-del tag
+```
+
+Cloning will create a new installation inside the same container. It
+will copy `/var/www/moodle` to `/var/www/moodle_tag`, `moodledata` to
+`moodledata_tag`, `dbname` to `dbname_tag`, etc. and make sure that
+the new installation can be accessed on
+https://tag.moodle1.example.org
+
+
+## Update and upgrade
+
+To update the current stable branch (for example from 3.3.1 to 3.3.2)
+use `ds update`. This is done quite frequently and usually has no
+risks of breaking anything.
+
+To upgrade to the next stable branch (for example from 3.2 to 3.3) use
+`ds upgrade moodle MOODLE_33_STABLE`. It will try to upgrade the
+additional plugins as well, if they have a version that matches the
+latest moodle release. However this does not always work and some
+plugins may need to be fixed manually.
+
+Since the upgrade process may be faced with some problems to be solved,
+it is better to try it first on a test site, and after making sure that
+everything works correctly, apply it to the real site. This can be done
+like this:
+```
+ds clone test
+ds upgrade moodle_test MOODLE_33_STABLE
+
+# make sure that everything works and fix any problems
+
+ds upgrade moodle MOODLE_33_STABLE
+ds clone-del test
+```
+
+Both update and upgrade make a backup before making any changes, just
+in case.
+
+
+## Remake
+
+The command `ds remake` rebuilds everything from scratch, but
+preserves the existing database and data files.

--- a/bash-completion.sh
+++ b/bash-completion.sh
@@ -1,0 +1,5 @@
+# bash completions for the command `ds restore`
+_ds_restore() {
+    local files_tgz=$(ls $(_ds_container_dir) | grep '\.tgz$')
+    COMPREPLY=( $(compgen -W "$files_tgz" -- $1) )
+}

--- a/cmd/backup.sh
+++ b/cmd/backup.sh
@@ -1,0 +1,47 @@
+cmd_backup_help() {
+    cat <<_EOF
+    backup [+d | +data]
+        Backup the Moodle database and config file.
+        With option +d, the data directory is included in the backup as well.
+
+_EOF
+}
+
+cmd_backup() {
+    # get the option +data
+    local data=0
+    [[ $1 == '+d' || $1 == '+data' ]] && data=1
+
+    # clear caches, enable maintenance mode, and stop the web server
+    local php='ds exec sudo --user=www-data php'
+    $php admin/cli/cron.php | grep 'task failed:'
+    $php admin/cli/maintenance.php --enable
+    $php admin/cli/purge_caches.php
+    ds exec service apache2 start
+
+    # create a directory for collecting the backup data
+    local datestamp=$(date +%F)
+    local dir=backup-$CONTAINER-$datestamp
+    rm -rf $dir/
+    mkdir -p $dir/
+
+    # dump the database
+    ds exec sh -c \
+        "mysqldump --allow-keywords --opt '$DBNAME' > /host/$dir/db.sql"
+
+    # copy the config file
+    cp var-www/moodle/config.php $dir/
+
+    # copy the data directory
+    [[ $data == 1 ]] && cp -a data/ $dir/
+
+    # make the backup archive
+    tar --create --gzip --preserve-permissions --file=$dir.tgz $dir/
+
+    # clean up
+    rm -rf $dir/
+
+    # start the web server and disable maintenance mode
+    ds exec service apache2 start
+    $php admin/cli/maintenance.php --disable
+}

--- a/cmd/cc.sh
+++ b/cmd/cc.sh
@@ -1,0 +1,18 @@
+cmd_cc_help() {
+    cat <<_EOF
+    cc
+        Clear the cache.
+
+_EOF
+}
+
+cmd_cc() {
+    local php='ds exec sudo --user=www-data php'
+    $php admin/cli/purge_caches.php
+
+    ds exec sh -c "rm -rf /host/data/cache/*"
+    ds exec sh -c "rm -rf /host/data/localcache/*"
+
+    ds exec chown www-data: /host/data/cache/
+    ds exec chown www-data: /host/data/localcache/
+}

--- a/cmd/clone-del.sh
+++ b/cmd/clone-del.sh
@@ -1,0 +1,22 @@
+cmd_clone-del_help() {
+    cat <<_EOF
+    clone-del <tag>
+        Delete clone 'moodle_<tag>'.
+
+_EOF
+}
+
+cmd_clone-del() {
+    local tag=$1
+    [[ -n $tag ]] || fail "Usage:\n$(cmd_clone-del_help)"
+
+    ds @wsproxy domains-rm $tag.$DOMAIN
+
+    ds @wsproxy exec sh -c "
+        cp /etc/hosts /etc/hosts.1 ;
+        sed -i /etc/hosts.1 -e '/$tag.$DOMAIN/d' ;
+        cat /etc/hosts.1 > /etc/hosts;
+        rm -f /etc/hosts.1"
+
+    ds inject clone-del.sh $tag
+}

--- a/cmd/clone.sh
+++ b/cmd/clone.sh
@@ -1,0 +1,29 @@
+cmd_clone_help() {
+    cat <<_EOF
+    clone <tag>
+        Make a clone from 'moodle' to 'moodle_<tag>'.
+        <tag> can be something like 'dev', 'test', '01', etc.
+
+_EOF
+}
+
+cmd_clone() {
+    local tag=$1
+    [[ -n $tag ]] || fail "Usage:\n $(cmd_clone_help)"
+
+    if [[ -d var-www/moodle_$tag ]]; then
+        echo "The clone 'moodle_$tag' already exists."
+        echo "Delete it first with: ds clone-del $tag"
+        exit 1
+    fi
+
+    # clone the site
+    ds inject clone.sh $tag
+
+    # add the new domain to wsproxy
+    ds @wsproxy domains-add $CONTAINER $tag.$DOMAIN
+
+    # add a new line on /etc/hosts @wsproxy
+    local ip=$(ds exec hostname --ip-address)
+    ds @wsproxy exec sh -c "echo '$ip $tag.$DOMAIN' >> /etc/hosts"
+}

--- a/cmd/config.sh
+++ b/cmd/config.sh
@@ -1,0 +1,33 @@
+cmd_config_help() {
+    cat <<_EOF
+    config
+        Run configuration scripts inside the container.
+
+_EOF
+}
+
+cmd_config() {
+    # run standard config scripts
+    ds inject ubuntu-fixes.sh
+    ds inject set_prompt.sh
+    # ds inject ssmtp.shs
+    # ds inject mariadb.sh
+    # ds inject apache2.sh
+
+    # run moodle config scripts
+    # ds inject cfg/01_mount_tmp_on_ram.sh
+    # ds inject cfg/02_fix_apache2_config.sh
+    # ds inject cfg/03_mariadb_config.sh
+    # ds inject cfg/04_create_db.sh
+    # ds inject cfg/05_moodle_install.sh
+    # ds inject cfg/06_moodle_config.sh
+    # ds inject cfg/07_setup_cron.sh
+    # ds inject cfg/08_setup_oauth2_google.sh
+    # ds inject cfg/09_bash_aliases.sh
+
+    # # install additional plugins
+    # ds install-plugins
+
+    # cleanup
+    ds cc
+}

--- a/cmd/create.sh
+++ b/cmd/create.sh
@@ -1,0 +1,18 @@
+cmd_create_help() {
+    cat <<_EOF
+    create
+        Create the container '$CONTAINER'.
+
+_EOF
+}
+
+rename_function cmd_create orig_cmd_create
+cmd_create() {
+    mkdir -p var-www/moodle
+    orig_cmd_create \
+        --mount type=bind,src=$(pwd)/var-www,dst=/var/www \
+        --workdir /var/www/moodle \
+        --env php='sudo --user=www-data php' \
+        --env moosh='sudo --user=www-data --set-home moosh --no-user-check' \
+        "$@"
+}

--- a/cmd/install-plugins.sh
+++ b/cmd/install-plugins.sh
@@ -1,0 +1,20 @@
+cmd_install-plugins_help() {
+    cat <<_EOF
+    install-plugins [<plugin>...]
+        Install Moodle additional plugins.
+        With no arguments installs the PLUGINS from 'settings.sh'
+
+_EOF
+}
+
+cmd_install-plugins() {
+    local plugins="$@"
+    [[ -n $plugins ]] || plugins="$PLUGINS"
+    [[ -n $plugins ]] || fail "Usage:\n$(cmd_install-plugins_help)"
+
+    # install plugins
+    ds inject install-plugins.sh $plugins
+
+    # config plugins
+    ds inject cfg/plugin/offlinequiz.sh
+}

--- a/cmd/remake.sh
+++ b/cmd/remake.sh
@@ -1,0 +1,28 @@
+cmd_remake_help() {
+    cat <<_EOF
+    remake
+        Reconstruct again the container, preserving the existing data.
+
+_EOF
+}
+
+cmd_remake() {
+    # backup
+    ds backup
+
+    # reinstall
+    ds remove
+    ds make
+    ds restart
+    ds wsproxy ssl-cert
+
+    # restore
+    local datestamp=$(date +%F)
+    local backup_file=backup-$CONTAINER-$datestamp.tgz
+    ds restore $backup_file
+    sleep 3
+
+    # run upgrade script
+    local php='ds exec sudo --user=www-data php'
+    $php admin/cli/upgrade.php --non-interactive
+}

--- a/cmd/restore.sh
+++ b/cmd/restore.sh
@@ -1,0 +1,43 @@
+cmd_restore_help() {
+    cat <<_EOF
+    restore <backup-file.tgz>
+        Restore Moodle from the given backup file.
+
+_EOF
+}
+
+cmd_restore() {
+    # get the backup file
+    local file=$1
+    test -f "$file" || fail "Usage: $COMMAND <backup-file.tgz>"
+    local dir=${file%%.tgz}
+    [[ $file != $dir ]] || fail "Usage: $COMMAND <backup-file.tgz>"
+
+    # extract the backup archive
+    tar --extract --gunzip --preserve-permissions --file=$file
+    dir=$(basename $dir)
+
+    # stop the web server
+    ds exec service apache2 stop
+
+    # restore the data/ directory
+    if [[ -d $dir/data/ ]]; then
+        [[ -d data ]] && mv data data-bak
+        cp -a $dir/data/ .
+    fi
+
+    # restore the config file
+    cp $dir/config.php var-www/moodle/
+
+    # restore the database
+    ds exec sh -c "mysql --database='$DBNAME' < /host/$dir/db.sql"
+
+    # cleanup
+    rm -rf $dir/
+
+    # start the web server
+    ds exec service apache2 start
+
+    # restart the container
+    ds restart
+}

--- a/cmd/update.sh
+++ b/cmd/update.sh
@@ -1,0 +1,14 @@
+cmd_update_help() {
+    cat <<_EOF
+    update [<target>]
+        Update Moodle. <target> can be 'moodle' (default) or
+        the name of a clone like: 'moodle_test', 'moodle_01', etc.
+
+_EOF
+}
+
+cmd_update() {
+    local target=${1:-moodle}
+    [[ $target == 'moodle' ]] && ds backup +data
+    ds inject update.sh $target
+}

--- a/cmd/upgrade.sh
+++ b/cmd/upgrade.sh
@@ -1,0 +1,26 @@
+cmd_upgrade_help() {
+    cat <<_EOF
+    upgrade <target> <moodle-branch>
+        Upgrade moodle version.
+        <target> can be 'moodle' (default) or the name
+        of a clone like: 'moodle_test', 'moodle_01', etc.
+        <moodle-branch> is a git branch like MOODLE_33_STABLE
+
+_EOF
+}
+
+cmd_upgrade() {
+    local target=$1
+    [[ -n $target ]] || fail "Usage:\n$(cmd_upgrade_help)"
+    [[ -d  var-www/$target ]] || fail "Directory var-www/$target does not exist."
+
+    local branch=$2
+    [[ -n $branch ]] || fail "Usage:\n$(cmd_upgrade_help)"
+    [[ $branch == $MOODLE_BRANCH ]] || fail "MOODLE_BRANCH on 'settings.sh' is different from $branch."
+
+    # make a backup
+    [[ $target == 'moodle' ]] && ds backup +data
+
+    # run upgrade
+    ds inject upgrade.sh $target $branch
+}

--- a/ds.sh
+++ b/ds.sh
@@ -1,0 +1,4 @@
+cmd_make() {
+    ds create
+    ds config
+}

--- a/errorlog
+++ b/errorlog
@@ -1,0 +1,228 @@
+# If /usr/share/plinth/actions/user main function is commented out
+
+(freedombox1-example-org)root@freedombox1-example-org:~# [2018-04-24 02:09:41,564] django.security.DisallowedHost ERROR    Invalid HTTP_HOST header: 'plinth.example.org, plinth.example.org'. The domain name provided is not valid according to RFC 1034/1035.
+
+# normal no edit
+# 
+
+ssh
+names
+help
+first_boot
+firewall
+config
+security
+apache
+datetime
+sso
+diagnostics
+users
+power
+networks
+letsencrypt
+upgrades
+avahi
+(freedombox1-example-org)root@freedombox1-example-org:/usr/local/lib/python3.6/dist-packages/plinth# plinth
+[2018-04-24 01:52:32,499] plinth.__main__ INFO     Configuration loaded from file - /etc/plinth/plinth.config
+[2018-04-24 01:52:32,499] plinth.__main__ INFO     Script prefix - /plinth
+[2018-04-24 01:52:32,509] axes.watch_login INFO     AXES: BEGIN LOG
+[2018-04-24 01:52:32,510] axes.watch_login INFO     AXES: Using django-axes 4.1.0
+[2018-04-24 01:52:32,510] axes.watch_login INFO     AXES: blocking by IP only.
+[2018-04-24 01:52:32,659] plinth.module_loader INFO     Module load order - ['roundcube', 'deluge', 'ttrss', 'quassel', 'ssh', 'names', 'pagekite', 'api', 'help', 'ikiwiki', 'openvpn', 'searx', 'tahoe', 'mumble', 'mediawiki', 'first_boot', 'tor', 'infinoted', 'firewall', 'config', 'security', 'apache', 'dynamicdns', 'bind', 'snapshot', 'minetest', 'ejabberd', 'datetime', 'monkeysphere', 'sharing', 'coquelicot', 'storage', 'sso', 'repro', 'diagnostics', 'jsxc', 'users', 'power', 'networks', 'privoxy', 'shadowsocks', 'transmission', 'matrixsynapse', 'letsencrypt', 'upgrades', 'cockpit', 'syncthing', 'radicale', 'avahi']
+[2018-04-24 01:52:36,252] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/pagekite', 'is-disabled']
+Unit pagekite.service could not be found.
+[2018-04-24 01:52:36,623] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/pagekite', 'get-kite']
+[2018-04-24 01:52:43,775] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/dynamicdns', 'status']
+[2018-04-24 01:52:55,753] plinth.setup   INFO     Running first setup.
+[2018-04-24 01:52:55,753] plinth.__main__ INFO     Setting up CherryPy server
+[2018-04-24 01:52:55,754] plinth.setup   INFO     Running setup for modules, essential - True, selected modules - None
+[2018-04-24 01:52:55,773] plinth.setup   INFO     Running module setup - users
+[2018-04-24 01:52:56,645] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:52:56,646] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'first-setup']
+[24/Apr/2018:01:52:56] ENGINE Listening for SIGTERM.
+[24/Apr/2018:01:52:56] ENGINE Listening for SIGHUP.
+[24/Apr/2018:01:52:56] ENGINE Listening for SIGUSR1.
+[24/Apr/2018:01:52:56] ENGINE Bus STARTING
+[24/Apr/2018:01:52:56] ENGINE Started monitor thread '_TimeoutMonitor'.
+[24/Apr/2018:01:52:56] ENGINE Serving on http://127.0.0.1:8000
+[24/Apr/2018:01:52:56] ENGINE Bus STARTED
+[2018-04-24 01:52:57,048] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:52:57,049] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup']
+[2018-04-24 01:52:59,172] plinth.actions ERROR    Error executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup'], , Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+debconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch
+slapd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable slapd
+nslcd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable nslcd
+ldap_add: Server is unwilling to perform (53)
+	additional info: no global superior knowledge
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit
+    ], stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s', 'base', '-b', 'ou=users,dc=thisbox', '(objectclass=*)']' returned non-zero exit status 32.
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 374, in <module>
+    main()
+  File "/usr/share/plinth/actions/users", line 370, in main
+    subcommand_method(arguments)
+  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup
+    configure_ldap_structure()
+  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure
+    create_organizational_unit('users')
+  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit
+    stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapadd', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///']' returned non-zero exit status 53.
+
+[2018-04-24 01:52:59,172] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 88, in run
+    self.module.setup(self, old_version=current_version)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/modules/users/__init__.py", line 62, in setup
+    helper.call('post', actions.superuser_run, 'users', ['setup'])
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 129, in call
+    return method(*args, **kwargs)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 118, in superuser_run
+    log_error=log_error)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 190, in _run
+    raise ActionError(action, output, error)
+plinth.errors.ActionError: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:52:59,175] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:52:59,176] plinth.setup   WARNING  Unable to complete setup: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:52:59,176] plinth.setup   INFO     Will try again in 10 seconds
+[2018-04-24 01:53:09,183] plinth.setup   INFO     Running first setup.
+[2018-04-24 01:53:09,184] plinth.setup   INFO     Running setup for modules, essential - True, selected modules - None
+[2018-04-24 01:53:09,201] plinth.setup   INFO     Running module setup - users
+[2018-04-24 01:53:10,065] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:53:10,065] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'first-setup']
+[2018-04-24 01:53:10,443] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:53:10,444] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup']
+[2018-04-24 01:53:12,626] plinth.actions ERROR    Error executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup'], , Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+debconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch
+slapd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable slapd
+nslcd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable nslcd
+ldap_add: Server is unwilling to perform (53)
+	additional info: no global superior knowledge
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit
+    ], stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s', 'base', '-b', 'ou=users,dc=thisbox', '(objectclass=*)']' returned non-zero exit status 32.
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 374, in <module>
+    main()
+  File "/usr/share/plinth/actions/users", line 370, in main
+    subcommand_method(arguments)
+  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup
+    configure_ldap_structure()
+  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure
+    create_organizational_unit('users')
+  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit
+    stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapadd', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///']' returned non-zero exit status 53.
+
+[2018-04-24 01:53:12,627] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 88, in run
+    self.module.setup(self, old_version=current_version)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/modules/users/__init__.py", line 62, in setup
+    helper.call('post', actions.superuser_run, 'users', ['setup'])
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 129, in call
+    return method(*args, **kwargs)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 118, in superuser_run
+    log_error=log_error)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 190, in _run
+    raise ActionError(action, output, error)
+plinth.errors.ActionError: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:12,628] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:12,628] plinth.setup   WARNING  Unable to complete setup: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:12,629] plinth.setup   INFO     Will try again in 10 seconds
+[2018-04-24 01:53:22,639] plinth.setup   INFO     Running first setup.
+[2018-04-24 01:53:22,640] plinth.setup   INFO     Running setup for modules, essential - True, selected modules - None
+[2018-04-24 01:53:22,652] plinth.setup   INFO     Running module setup - users
+[2018-04-24 01:53:23,510] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:53:23,510] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'first-setup']
+[2018-04-24 01:53:23,881] plinth.setup   INFO     Running step for module - users, step - post
+[2018-04-24 01:53:23,882] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup']
+[2018-04-24 01:53:25,998] plinth.actions ERROR    Error executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup'], , Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
+debconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch
+slapd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable slapd
+nslcd.service is not a native service, redirecting to systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install enable nslcd
+ldap_add: Server is unwilling to perform (53)
+	additional info: no global superior knowledge
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit
+    ], stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s', 'base', '-b', 'ou=users,dc=thisbox', '(objectclass=*)']' returned non-zero exit status 32.
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/usr/share/plinth/actions/users", line 374, in <module>
+    main()
+  File "/usr/share/plinth/actions/users", line 370, in main
+    subcommand_method(arguments)
+  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup
+    configure_ldap_structure()
+  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure
+    create_organizational_unit('users')
+  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit
+    stdout=subprocess.DEVNULL, check=True)
+  File "/usr/lib/python3.6/subprocess.py", line 418, in run
+    output=stdout, stderr=stderr)
+subprocess.CalledProcessError: Command '['ldapadd', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///']' returned non-zero exit status 53.
+
+[2018-04-24 01:53:25,998] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 88, in run
+    self.module.setup(self, old_version=current_version)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/modules/users/__init__.py", line 62, in setup
+    helper.call('post', actions.superuser_run, 'users', ['setup'])
+  File "/usr/local/lib/python3.6/dist-packages/plinth/setup.py", line 129, in call
+    return method(*args, **kwargs)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 118, in superuser_run
+    log_error=log_error)
+  File "/usr/local/lib/python3.6/dist-packages/plinth/actions.py", line 190, in _run
+    raise ActionError(action, output, error)
+plinth.errors.ActionError: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:25,999] plinth.setup   ERROR    Error running setup - ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:26,000] plinth.setup   WARNING  Unable to complete setup: ('users', '', 'Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ninvoke-rc.d: policy-rc.d denied execution of restart.\nUse of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.\ndebconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch\nslapd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable slapd\nnslcd.service is not a native service, redirecting to systemd-sysv-install.\nExecuting: /lib/systemd/systemd-sysv-install enable nslcd\nldap_add: Server is unwilling to perform (53)\n\tadditional info: no global superior knowledge\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit\n    ], stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapsearch\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\', \'-s\', \'base\', \'-b\', \'ou=users,dc=thisbox\', \'(objectclass=*)\']\' returned non-zero exit status 32.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/share/plinth/actions/users", line 374, in <module>\n    main()\n  File "/usr/share/plinth/actions/users", line 370, in main\n    subcommand_method(arguments)\n  File "/usr/share/plinth/actions/users", line 113, in subcommand_setup\n    configure_ldap_structure()\n  File "/usr/share/plinth/actions/users", line 142, in configure_ldap_structure\n    create_organizational_unit(\'users\')\n  File "/usr/share/plinth/actions/users", line 163, in create_organizational_unit\n    stdout=subprocess.DEVNULL, check=True)\n  File "/usr/lib/python3.6/subprocess.py", line 418, in run\n    output=stdout, stderr=stderr)\nsubprocess.CalledProcessError: Command \'[\'ldapadd\', \'-Q\', \'-Y\', \'EXTERNAL\', \'-H\', \'ldapi:///\']\' returned non-zero exit status 53.\n')
+[2018-04-24 01:53:26,000] plinth.setup   INFO     Will try again in 10 seconds
+^C[24/Apr/2018:01:53:28] ENGINE Keyboard Interrupt: shutting down bus
+[24/Apr/2018:01:53:28] ENGINE Bus STOPPING
+[24/Apr/2018:01:53:28] ENGINE HTTP Server cherrypy._cpwsgi_server.CPWSGIServer(('127.0.0.1', 8000)) shut down
+[24/Apr/2018:01:53:28] ENGINE Stopped thread '_TimeoutMonitor'.
+[24/Apr/2018:01:53:28] ENGINE Bus STOPPED
+[24/Apr/2018:01:53:28] ENGINE Bus EXITING
+[24/Apr/2018:01:53:28] ENGINE Bus EXITED
+[24/Apr/2018:01:53:28] ENGINE Waiting for child threads to terminate...
+[24/Apr/2018:01:53:28] ENGINE Waiting for thread Thread-1.
+[2018-04-24 01:53:36,003] plinth.setup   INFO     Setup thread finished.
+(freedombox1-example-org)root@freedombox1-example-org:/usr/local/lib/python3.6/dist-packages/plinth# 

--- a/scripts/cfg/01_mount_tmp_on_ram.sh
+++ b/scripts/cfg/01_mount_tmp_on_ram.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+### mount /tmp on RAM for better performance
+
+sed -i /etc/fstab \
+    -e '/appended by installation scripts/,$ d'
+
+cat <<_EOF >> /etc/fstab
+### appended by installation scripts
+tmpfs	 /dev/shm                 tmpfs    defaults,noexec,nosuid               0    0
+devpts	 /dev/pts                 devpts   rw,noexec,nosuid,gid=5,mode=620      0    0
+# tmpfs    /host/data/cache         tmpfs    defaults,noatime,mode=1777,nosuid    0    0
+# tmpfs    /host/data/localcache    tmpfs    defaults,noatime,mode=1777,nosuid    0    0
+_EOF
+
+mount -a

--- a/scripts/cfg/02_fix_apache2_config.sh
+++ b/scripts/cfg/02_fix_apache2_config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+### fix apache2 config
+
+sed -i /etc/apache2/sites-available/default.conf \
+    -e 's#/var/www/default#/var/www/moodle#g'
+
+service apache2 reload

--- a/scripts/cfg/03_mariadb_config.sh
+++ b/scripts/cfg/03_mariadb_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+### fix mariadb config
+
+cat <<EOF > /etc/mysql/conf.d/moodle.cnf
+[mysqld]
+default_storage_engine = innodb
+innodb_file_per_table = 1
+innodb_file_format = Barracuda
+innodb_large_prefix = ON
+binlog_format = ROW
+EOF
+
+### restart service
+service mysql restart

--- a/scripts/cfg/04_create_db.sh
+++ b/scripts/cfg/04_create_db.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+### create the database and user
+
+source /host/settings.sh
+
+mysql -e "
+    DROP DATABASE IF EXISTS $DBNAME;
+    CREATE DATABASE $DBNAME;
+    GRANT ALL ON $DBNAME.* TO $DBUSER@localhost IDENTIFIED BY '$DBPASS';
+"

--- a/scripts/cfg/05_moodle_install.sh
+++ b/scripts/cfg/05_moodle_install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -x
+### install moodle
+
+source /host/settings.sh
+
+### create a directory for moodle data
+mkdir -p /host/data
+chown -R www-data /host/data
+chmod -R 777 /host/data
+
+### copy moodle code
+if [[ ! -f /var/www/moodle/config.php ]]; then
+    rm -rf /var/www/moodle
+    cp -a /usr/local/src/moodle /var/www/
+fi
+
+### go to the moodle directory
+cd /var/www/moodle/
+
+### Get $MOODLE_BRANCH from git.
+git pull
+git checkout $MOODLE_BRANCH
+
+### set some configuration defaults
+cat <<_EOF > local/defaults.php
+<?php
+\$defaults['moodle']['smtphosts'] = 'smtp.gmail.com:465';
+\$defaults['moodle']['smtpsecure'] = 'ssl';
+\$defaults['moodle']['smtpauthtype'] = 'LOGIN';
+\$defaults['moodle']['smtpuser'] = '$GMAIL_ADDRESS';
+\$defaults['moodle']['smtppass'] = '$GMAIL_PASSWD';
+_EOF
+
+### fix ownership
+chown -R www-data: /var/www
+
+### install moodle
+if [[ -f /var/www/moodle/config.php ]]; then
+    $php admin/cli/install_database.php \
+        --agree-license \
+        --lang="$SITE_LANG" --fullname="$SITE_FULLNAME" --shortname="$SITE_SHORTNAME" \
+        --adminuser="$ADMIN_USER" --adminpass="$ADMIN_PASS" --adminemail="$ADMIN_EMAIL"
+else
+    $php admin/cli/install.php \
+        --non-interactive --agree-license \
+        --wwwroot="https://$DOMAIN" --dataroot="/host/data" \
+        --dbtype="mariadb" --dbname="$DBNAME" --dbuser="$DBUSER" --dbpass="$DBPASS" \
+        --lang="$SITE_LANG" --fullname="$SITE_FULLNAME" --shortname="$SITE_SHORTNAME" \
+        --adminuser="$ADMIN_USER" --adminpass="$ADMIN_PASS" --adminemail="$ADMIN_EMAIL"
+fi

--- a/scripts/cfg/06_moodle_config.sh
+++ b/scripts/cfg/06_moodle_config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+### moodle configuration
+
+source /host/settings.sh
+
+### set the name of the admin user
+mysql --database=$DBNAME -B -e \
+          "UPDATE mdl_user
+           SET firstname='$SITE_SHORTNAME', lastname='Admin'
+           WHERE username='admin'"
+
+$moosh config-set theme more    # set theme
+$moosh config-set registerauth email
+
+### set smtp settings
+$moosh config-set smtphosts 'smtp.gmail.com:465'
+$moosh config-set smtpsecure ssl
+$moosh config-set smtpauthtype LOGIN
+$moosh config-set smtpuser $GMAIL_ADDRESS
+$moosh config-set smtppass "$GMAIL_PASSWD"
+
+$moosh plugin-list >/dev/null

--- a/scripts/cfg/07_setup_cron.sh
+++ b/scripts/cfg/07_setup_cron.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+### setup cron
+
+### run moodle cron every minute
+echo "* * * * * www-data /usr/bin/php /var/www/moodle/admin/cli/cron.php >> /var/log/cron.log 2>&1" > /etc/cron.d/moodle
+touch /var/log/cron.log
+chown www-data /var/log/cron.log

--- a/scripts/cfg/08_setup_oauth2_google.sh
+++ b/scripts/cfg/08_setup_oauth2_google.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -x
+### moodle configuration
+
+$moosh auth-manage enable oauth2
+$moosh auth-manage up oauth2
+
+### get $DBNAME,  $GOOGLE_CLIENT_ID, $GOOGLE_CLIENT_SECRET
+source /host/settings.sh
+
+[[ -n $GOOGLE_CLIENT_ID ]] || exit
+
+timestamp=$(date +%s)
+
+mysql --database=$DBNAME -B -e "
+    INSERT INTO mdl_oauth2_issuer
+        (id, timecreated, timemodified, usermodified, name, image, baseurl,
+        clientid, clientsecret, loginscopes, loginscopesoffline, loginparams,
+        loginparamsoffline, alloweddomains, scopessupported, enabled, showonloginpage,
+        sortorder)
+    VALUES
+        (1, $timestamp, $timestamp, 2, 'Google', 'https://accounts.google.com/favicon.ico',
+        'http://accounts.google.com/', '$GOOGLE_CLIENT_ID', '$GOOGLE_CLIENT_SECRET',
+        'openid profile email', 'openid profile email', '', 'access_type=offline&prompt=consent',
+        '', 'openid email profile', 1, 1, 0);
+    "
+
+mysql --database=$DBNAME -B -e "
+    INSERT INTO mdl_oauth2_endpoint
+        (id, timecreated, timemodified, usermodified, name, url, issuerid)
+    VALUES
+        (1, $timestamp, $timestamp, 2, 'discovery_endpoint', 'https://accounts.google.com/.well-known/openid-configuration', 1),
+        (2, $timestamp, $timestamp, 2, 'authorization_endpoint', 'https://accounts.google.com/o/oauth2/v2/auth', 1),
+        (3, $timestamp, $timestamp, 2, 'token_endpoint', 'https://www.googleapis.com/oauth2/v4/token', 1),
+        (4, $timestamp, $timestamp, 2, 'userinfo_endpoint', 'https://www.googleapis.com/oauth2/v3/userinfo', 1),
+        (5, $timestamp, $timestamp, 2, 'revocation_endpoint', 'https://accounts.google.com/o/oauth2/revoke', 1);
+    "
+
+mysql --database=$DBNAME -B -e "
+    INSERT INTO mdl_oauth2_user_field_mapping
+        (id, timemodified, timecreated, usermodified, issuerid, externalfield, internalfield)
+    VALUES
+        (1, $timestamp, $timestamp, 2, 1, 'given_name', 'firstname'),
+        (2, $timestamp, $timestamp, 2, 1, 'middle_name', 'middlename'),
+        (3, $timestamp, $timestamp, 2, 1, 'family_name', 'lastname'),
+        (4, $timestamp, $timestamp, 2, 1, 'email', 'email'),
+        (5, $timestamp, $timestamp, 2, 1, 'website', 'url'),
+        (6, $timestamp, $timestamp, 2, 1, 'nickname', 'alternatename'),
+        (7, $timestamp, $timestamp, 2, 1, 'picture', 'picture'),
+        (8, $timestamp, $timestamp, 2, 1, 'address', 'address'),
+        (9, $timestamp, $timestamp, 2, 1, 'phone', 'phone1'),
+        (10, $timestamp, $timestamp, 2, 1, 'locale', 'lang');
+    "

--- a/scripts/cfg/09_bash_aliases.sh
+++ b/scripts/cfg/09_bash_aliases.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+### setup aliases
+
+cat <<_EOF > /root/.bash_aliases
+alias php='sudo --user=www-data php'
+alias moosh='sudo --user=www-data --set-home moosh --no-user-check'
+_EOF

--- a/scripts/cfg/plugin/offlinequiz.sh
+++ b/scripts/cfg/plugin/offlinequiz.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+### config mod_offlinequiz
+
+$moosh config-set shufflequestions 1 offlinequiz
+$moosh config-set shuffleanswers 1 offlinequiz
+
+source /host/settings.sh
+$moosh config-set logourl "$OFFLINEQUIZ_LOGOURL" offlinequiz

--- a/scripts/clone-del.sh
+++ b/scripts/clone-del.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+### delete a clone of the main moodle site
+
+tag=$1
+[[ -z $tag ]] && echo "Usage: $0 <tag>" && exit 1
+
+### delete apache2 config
+a2dissite moodle_$tag
+find -L -samefile /etc/apache2/sites-available/moodle_$tag.conf | xargs rm -f
+service apache2 restart
+
+### remove the code and the data
+rm -rf /var/www/moodle_$tag
+rm -rf /host/data_$tag
+
+### drop the database
+source /host/settings.sh
+mysql -e "DROP DATABASE IF EXISTS ${DBNAME}_$tag;"

--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -x
+### make a clone of the main moodle site
+
+tag=$1
+[[ -z $tag ]] && echo "Usage: $0 <tag>" && exit 1
+
+source /host/settings.sh
+moodle="moodle_$tag"
+data="data_$tag"
+dbname="${DBNAME}_$tag"
+domain="$tag.$DOMAIN"
+[[ -d /var/www/$moodle ]] && echo "Clone '$moodle' already exists." && exit 1
+
+### clone the data
+rm -rf /host/$data
+cp -a /host/data /host/$data
+
+### clone the code
+rm -rf /var/www/$moodle
+cp -a  /var/www/moodle /var/www/$moodle
+
+# fix moodle config file
+sed -i /var/www/$moodle/config.php \
+    -e "/^\$CFG->dbname/ c \$CFG->dbname    = '$dbname';" \
+    -e "/^\$CFG->wwwroot/ c \$CFG->wwwroot   = 'https://$domain';" \
+    -e "/^\$CFG->dataroot/ c \$CFG->dataroot  = '/host/$data';"
+
+### create a new database
+mysql -e "
+        DROP DATABASE IF EXISTS $dbname;
+        CREATE DATABASE $dbname;
+        GRANT ALL ON $dbname.* TO $DBUSER@localhost;
+    "
+# copy the data of the database
+mysqldump --allow-keywords --opt $DBNAME | mysql --database=$dbname
+
+# replace the old domain with the new one in the database
+cd /var/www/$moodle
+$php admin/tool/replace/cli/replace.php --search="$DOMAIN" --replace="$domain"
+
+# clear the cache
+cd /var/www/$moodle
+$php admin/cli/purge_caches.php
+
+# copy and modify the configuration of apache2
+find -L -samefile /etc/apache2/sites-available/$moodle.conf | xargs rm -f
+cp /etc/apache2/sites-available/{default,$moodle}.conf
+sed -i /etc/apache2/sites-available/$moodle.conf \
+    -e "s#ServerName .*#ServerName $domain#" \
+    -e "s#RedirectPermanent .*#RedirectPermanent / https://$domain/#" \
+    -e "s#/var/www/moodle#/var/www/$moodle#g"
+ln /etc/apache2/sites-available/{$moodle,$domain}.conf
+a2ensite $moodle
+cd -
+
+# restart apache2
+service apache2 restart

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+### Install the plugins given as arguments.
+
+source /host/settings.sh
+
+plugins="$@"
+[[ -z $plugins ]] && echo "No plugins to install" && exit
+
+moodle_version=$(echo $MOODLE_BRANCH | cut -d_ -f2)
+for plugin in $plugins; do
+    latest_version=$($moosh plugin-list -v | grep $plugin | tr , "\n" | sed '/https/d' | tail -1)
+    support=$($moosh plugin-list | grep $plugin | tr , "\n" | sed '/https/d' | tr -d . | grep $moodle_version)
+    if [[ -n $support ]]; then
+        # install the latest version of the plugin
+        $moosh plugin-install -d -f $plugin $latest_version
+    else
+        echo "Plugin '$plugin' does not support yet $MOODLE_BRANCH."
+        echo "If you know what you are doing, you can install it anyway"
+        echo "manually with the command:"
+        echo "    ds exec sh -c '\$moosh plugin-install -d -f $plugin $latest_version'"
+        echo
+    fi
+done
+
+### update the database
+$php admin/cli/upgrade.php --non-interactive
+$php admin/cli/purge_caches.php

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -x
+### Update Moodle.
+
+### go to the moodle directory
+target=${1:-moodle}
+cd /var/www/$target
+
+### run cron, enable maintenance mode and purge caches
+$php admin/cli/cron.php | grep 'task failed:'
+$php admin/cli/maintenance.php --enable
+$php admin/cli/purge_caches.php
+
+### update moodle code with 'git pull'
+git stash
+git pull
+git stash pop
+chown www-data: -R .
+
+### update the database
+$php admin/cli/upgrade.php --non-interactive
+
+### purge caches, disable maintenance mode and run cron
+$php admin/cli/purge_caches.php
+$php admin/cli/maintenance.php --disable
+$php admin/cli/cron.php | grep 'task failed:'

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+### Upgrade moodle version, for example from 3.2 to 3.3
+
+fail() { echo -n "$@" >&2 ; exit 1; }
+
+source /host/settings.sh
+
+### get the target directory to be upgraded
+target=$1
+[[ -n $target ]] || fail "Usage: $0 <target> <branch>"
+[[ -d  /var/www/$target ]] || fail "Directory  /var/www/$target does not exist."
+
+### get the branch to upgrade to (something like MOODLE_33_STABLE)
+branch=$2
+[[ -n $branch ]] || fail "Usage: $0 <target> <branch>"
+[[ $branch == $MOODLE_BRANCH ]] || fail "MOODLE_BRANCH on 'settings.sh' is different from $branch."
+
+### go to the target directory
+cd /var/www/$target
+
+### run cron, enable maintenance mode and purge caches
+$php admin/cli/cron.php | grep 'task failed:'
+$php admin/cli/maintenance.php --enable
+$php admin/cli/purge_caches.php
+
+### update moodle code with 'git pull'
+git stash
+git fetch
+git checkout $branch
+git pull
+git stash pop
+
+### update plugins
+moodle_version=$(echo $branch | cut -d_ -f2)
+for file in $(git ls-files -o | grep version.php); do
+    release=$(cat $file | grep '\->release' | cut -d= -f2 | tr -d " ';")
+    [[ -z $release ]] && continue
+    plugin=$(cat $file | grep '\->component' | cut -d= -f2 | tr -d " ';")
+    latest_version=$($moosh plugin-list -v | grep $plugin | tr , "\n" | sed '/https/d' | tail -1)
+    support=$($moosh plugin-list | grep $plugin | tr , "\n" | sed '/https/d' | tr -d . | grep $moodle_version)
+    if [[ -n $support ]]; then
+        # install the latest version of the plugin
+        $moosh plugin-install -d -f $plugin $latest_version
+    else
+        echo "Plugin '$plugin' does not support yet the latest version of moodle ($release)."
+        read -p "Keep it anyway? [y/N]: " ans
+        ans=${ans:-n}
+        ans=${ans,}
+        if [[ $ans == 'y' ]]; then
+            $moosh plugin-install -d -f $plugin $latest_version
+        else
+            rm -rf $(dirname $file)
+            echo "Plugin directory $(dirname $file) was removed."
+            echo "Try to add it manually later."
+        fi
+    fi
+done
+
+### fix ownership
+chown www-data: -R .
+
+### update the database
+$php admin/cli/upgrade.php --non-interactive
+
+### purge caches, disable maintenance mode and run cron
+$php admin/cli/purge_caches.php
+$php admin/cli/maintenance.php --disable
+$php admin/cli/cron.php | grep 'task failed:'

--- a/settings.sh
+++ b/settings.sh
@@ -1,0 +1,50 @@
+APP=freedombox
+MOODLE_BRANCH=MOODLE_34_STABLE
+
+### Docker settings.
+IMAGE=dockerscripts/freedombox
+CONTAINER=freedombox1-example-org
+#PORTS=
+
+DOMAIN="plinth.example.org"
+
+### MySQL settings
+DBNAME=plinth
+DBUSER=plint
+DBPASS=plinth
+
+### Gmail account for notifications.
+### Make sure to enable less-secure-apps:
+### https://support.google.com/accounts/answer/6010255?hl=en
+GMAIL_ADDRESS=
+GMAIL_PASSWD=
+
+### freedombox site settings.
+SITE_LANG=en
+SITE_FULLNAME="freedombox Example 1"
+SITE_SHORTNAME="MDL1"
+
+### Admin settings.
+ADMIN_USER=admin
+ADMIN_PASS="admin-1234"
+ADMIN_EMAIL=admin@example.org
+
+### Settings for register/login with OAuth2.
+### See: https://developers.google.com/adwords/api/docs/guides/authentication#webapp
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+### Additional plugins to be installed.
+PLUGINS="
+    mod_bigbluebuttonbn
+    mod_recordingsbn
+    mod_offlinequiz
+    qbehaviour_adaptive_adapted_for_coderunner
+    qtype_coderunner
+    atto_mathslate
+    tinymce_mathslate
+    mod_webrtcexperiments
+"
+
+### Settings for the plugin offlinequiz.
+OFFLINEQUIZ_LOGOURL=


### PR DESCRIPTION
My initial freedombox container.
This Dockerfile installs Plinth and configures apache.
*I will update the README.md later.

- to test this Dockerfile, change .ds/config.sh content, GITHUB='https://github.com/RadZaeem'

What I did
- Use docker-scripts/moodle repo and docker-scripts/debian/Dockerfile as base a
- Create a Dockerfile https://github.com/RadZaeem/freedombox/blob/master/Dockerfile
  - put install steps from INSTALL.md from https://salsa.debian.org/freedombox-team/plinth
- Run plinth manually with `ds shell` then run `plinth` inside container

To build
```
# edit first .ds/config.sh, GITHUB='https://github.com/RadZaeem'
ds pull freedombox
ds init freedombox @freedombox
ds build
ds make
```

To run
```
cd  /var/ds/freedombox
ds shell
plinth #inside container
# Ctrl-C to quit
```

Problems I found:
  - error log: https://github.com/RadZaeem/freedombox/blob/master/errorlog
  - plinth's /usr/share/plinth/actions/users python file executes LDAP setup, but it cannot configure correctly in side Docker, hence throwing errors.
```
(freedombox1-example-org)root@freedombox1-example-org:/usr/local/lib/python3.6/dist-packages/plinth# plinth
[2018-04-24 01:52:32,499] plinth.__main__ INFO     Configuration loaded from file - /etc/plinth/plinth.config
[2018-04-24 01:52:32,499] plinth.__main__ INFO     Script prefix - /plinth
[2018-04-24 01:52:32,509] axes.watch_login INFO     AXES: BEGIN LOG
[2018-04-24 01:52:32,510] axes.watch_login INFO     AXES: Using django-axes 4.1.0
[2018-04-24 01:52:32,510] axes.watch_login INFO     AXES: blocking by IP only.
[2018-04-24 01:52:32,659] plinth.module_loader INFO     Module load order - ['roundcube', 'deluge', 'ttrss', 'quassel', 'ssh', 'names', 'pagekite', 'api', 'help', 'ikiwiki', 'openvpn', 'searx', 'tahoe', 'mumble', 'mediawiki', 'first_boot', 'tor', 'infinoted', 'firewall', 'config', 'security', 'apache', 'dynamicdns', 'bind', 'snapshot', 'minetest', 'ejabberd', 'datetime', 'monkeysphere', 'sharing', 'coquelicot', 'storage', 'sso', 'repro', 'diagnostics', 'jsxc', 'users', 'power', 'networks', 'privoxy', 'shadowsocks', 'transmission', 'matrixsynapse', 'letsencrypt', 'upgrades', 'cockpit', 'syncthing', 'radicale', 'avahi']
[2018-04-24 01:52:36,252] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/pagekite', 'is-disabled']
Unit pagekite.service could not be found.
[2018-04-24 01:52:36,623] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/pagekite', 'get-kite']
[2018-04-24 01:52:43,775] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/dynamicdns', 'status']
[2018-04-24 01:52:55,753] plinth.setup   INFO     Running first setup.
[2018-04-24 01:52:55,753] plinth.__main__ INFO     Setting up CherryPy server
[2018-04-24 01:52:55,754] plinth.setup   INFO     Running setup for modules, essential - True, selected modules - None
[2018-04-24 01:52:55,773] plinth.setup   INFO     Running module setup - users
[2018-04-24 01:52:56,645] plinth.setup   INFO     Running step for module - users, step - post
[2018-04-24 01:52:56,646] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'first-setup']
[24/Apr/2018:01:52:56] ENGINE Listening for SIGTERM.
[24/Apr/2018:01:52:56] ENGINE Listening for SIGHUP.
[24/Apr/2018:01:52:56] ENGINE Listening for SIGUSR1.
[24/Apr/2018:01:52:56] ENGINE Bus STARTING
[24/Apr/2018:01:52:56] ENGINE Started monitor thread '_TimeoutMonitor'.
[24/Apr/2018:01:52:56] ENGINE Serving on http://127.0.0.1:8000
[24/Apr/2018:01:52:56] ENGINE Bus STARTED
[2018-04-24 01:52:57,048] plinth.setup   INFO     Running step for module - users, step - post
[2018-04-24 01:52:57,049] plinth.actions INFO     Executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup']
[2018-04-24 01:52:59,172] plinth.actions ERROR    Error executing command - ['sudo', '-n', '/usr/share/plinth/actions/users', 'setup'], , Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
invoke-rc.d: policy-rc.d denied execution of restart.
Use of uninitialized value $item in hash element at /usr/share/perl5/Debconf/DbDriver/File.pm line 85, <__ANONIO__> chunk 1.
debconf: DbDriver "_ENV_stack": unable to save changes to: libnss-ldapd/nsswitch
slapd.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable slapd
nslcd.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable nslcd
ldap_add: Server is unwilling to perform (53)
	additional info: no global superior knowledge
Traceback (most recent call last):
  File "/usr/share/plinth/actions/users", line 153, in create_organizational_unit
    ], stdout=subprocess.DEVNULL, check=True)
  File "/usr/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s', 'base', '-b', 'ou=users,dc=thisbox', '(objectclass=*)']' returned non-zero exit status 32.

During handling of the above exception, another exception occurred:

```
  - I edited manually inside ds shell the said file, by disabling its main() function, so that plinth skips LDAP user setup, and the errors can be avoided temporarily
```
vi /usr/share/actions/users
#edit line 363, add return the line below `def main():`
# then re-run plinth
plinth &
```
  - I still haven't tested and configured properly with wsproxy, I just configured my /etc/hosts to redirect localhost to plinth.example.org.

When I try to access with my web browser, django throw security error:
```

(freedombox1-example-org)root@freedombox1-example-org:~# [2018-04-24 02:09:41,564] django.security.DisallowedHost ERROR    Invalid HTTP_HOST header: 'plinth.example.org, plinth.example.org'. The domain name provided is not valid according to RFC 1034/1035.

```
  - But I can access and continue setup normally if I use w3m text-based web browser inside container
```
# inside container
apt install -y w3m
w3m localhost
```






```